### PR TITLE
fix: set background to transparent

### DIFF
--- a/src/screens/login/components/LoadingFullScreen.js
+++ b/src/screens/login/components/LoadingFullScreen.js
@@ -13,7 +13,7 @@ export default function LoadingFullScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#000",
+    backgroundColor: "transparent",
     alignItems: "center",
     justifyContent: "center",
   },


### PR DESCRIPTION
This commit fixes a glitch where a black rectangle appears behind the loading component